### PR TITLE
Use latest version of property-expr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "json-ref-lite",
+  "version": "1.0.73",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "json-ref-lite",
+      "version": "1.0.73",
+      "license": "ISC",
+      "dependencies": {
+        "property-expr": "^2.0.6"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+    }
+  },
+  "dependencies": {
+    "property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "json-ref-lite",
-  "version": "1.0.73",
-  "description":"Extremely light weight way to resolve jsonschema '$ref' references & inheritance: create circular/graphs, fractals from json (browser/coffeescript/javascript).",
+  "version": "1.0.74",
+  "description": "Extremely light weight way to resolve jsonschema '$ref' references & inheritance: create circular/graphs, fractals from json (browser/coffeescript/javascript).",
   "main": "index.js",
   "dependencies": {
-    "property-expr": "^1.3.1"
+    "property-expr": "^2.0.6"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "coffee test/test.coffee > test/test.now ; diff --brief test/test.now test/test.out && echo 'test OK' || exit 1",
     "browser": "/bin/bash -c 'coffee -c *.coffee test/*.coffee && browserify -r .:json-ref-lite | uglifyjs -o json-ref-lite.min.js'"


### PR DESCRIPTION
-  Use latest version of property-expr node module to fix security issue (`npm audit fix --force`)
-  Ignore node_modules folder
-  Bump forked jsonr-ref-lite version